### PR TITLE
Fix clean_db function to return a shallow copy of the db

### DIFF
--- a/build_arcade_roms_db.py
+++ b/build_arcade_roms_db.py
@@ -301,6 +301,7 @@ def run(cmd, fail_ok=False, shell=False, stderr=subprocess.STDOUT, stdout=None):
     return proc
 
 def clean_db(db):
+    db = db.copy()
     db['timestamp'] = 0
     return db
 


### PR DESCRIPTION
Not copying the db causes to mutate the original db and to lose the timestamp in the resulting artifact.