### PR TITLE
Decode percent-encoded source URLs before generating download URLs

### DIFF
--- a/build_arcade_roms_db.py
+++ b/build_arcade_roms_db.py
@@ -9,6 +9,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 import time
 import shlex
 import difflib
+from urllib.parse import unquote
 
 _print = print
 def print(text=""):
@@ -109,14 +110,14 @@ def main():
                     "version": mameversion,
                     "size": hash_description['size'],
                     "hbmame": is_hbmame,
-                    "url": sources['hbmame' if is_hbmame else 'mame'][mameversion] + (hash_description['fullpath'] if 'fullpath' in hash_description else zip_name),
+                    "url": unquote(sources['hbmame' if is_hbmame else 'mame'][mameversion]) + (hash_description['fullpath'] if 'fullpath' in hash_description else zip_name),
 
                 }
             else:
                 files[games_path] = {
                     "hash": hash_description['md5'],
                     "size": hash_description['size'],
-                    "url": sources['hbmame' if is_hbmame else 'mame'][mameversion] + (hash_description['fullpath'] if 'fullpath' in hash_description else zip_name),
+                    "url": unquote(sources['hbmame' if is_hbmame else 'mame'][mameversion]) + (hash_description['fullpath'] if 'fullpath' in hash_description else zip_name),
                     "tags": tags
                 }
             


### PR DESCRIPTION
Some entries in arcade_sources.json (e.g. MAME 0.217/0.218) store the base URL with percent-encoded spaces, causing the generated download URLs to contain literal %20 sequences in the zip filename path. This makes URLs harder to read and can confuse parsers that misinterpret %200 as a single encoded character rather than %20 followed by the digit 0.

urllib.parse.unquote() on the base URL before concatenating the zip name produces clean URLs with raw spaces, consistent with how other source entries (e.g. fallback) already emit their paths.

Discovered issue with mameversion 0218 for:
Star Wars (Rev 2).mra
Empire Strikes Back.mra 